### PR TITLE
Multitensor

### DIFF
--- a/fggs/sum_product.py
+++ b/fggs/sum_product.py
@@ -196,10 +196,8 @@ class MultiTensor:
     def __torch_function__(cls, func, types, args=(), kwargs=None):
         if kwargs is None:
             kwargs = {}
-        args = [a._t if hasattr(a, '_t') else a for a in args]
-        metadata = tuple(a.nt_dict if hasattr(a, 'nt_dict') else a for a in args)
-        assert len(metadata) > 0
-        return MultiTensor(func(*args, **kwargs), nt_dict=metadata[0])
+        args = [a._t if isinstance(a, MultiTensor) else a for a in args]
+        return func(*args, **kwargs)
     
 
 def F(fgg: FGG, x: MultiTensor, inputs: Dict[EdgeLabel, Tensor]) -> MultiTensor:

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -154,8 +154,7 @@ class TestMultiTensor(unittest.TestCase):
     def test_ops(self):
         x = MultiTensor.initialize(self.fgg_1)
         y = x + 1.
-        self.assertIsInstance(y, MultiTensor)
-        self.assertTrue(torch.norm(y.dict[self.X] - (x.dict[self.X] + 1.)) < 1e-6)
+        self.assertTrue(torch.norm(y - (x._t + 1.)) < 1e-6)
         
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #98.

Since `MultiTensor.__torch_function__` was not returning a valid MultiTensor, I just made it return a Tensor.

In the future if we need something fancier I guess we can make it fancier.
