### PR TITLE
Ensure conjunction and factorize do not make edge label collisions

### DIFF
--- a/fggs/conjunction.py
+++ b/fggs/conjunction.py
@@ -13,7 +13,7 @@ def nonterminal_pairs(hrg1, hrg2):
     """
 
     nt_map = {}
-    labels = set(hrg1.terminals()) | set(hrg2.terminals())
+    labels = set(hrg1.edge_labels()) | set(hrg2.edge_labels())
     for el1 in hrg1.nonterminals():
         for el2 in hrg2.nonterminals():
             new_nt_name = f'<{el1.name},{el2.name}>'

--- a/fggs/fggs.py
+++ b/fggs/fggs.py
@@ -157,6 +157,10 @@ class Graph:
     def edges(self):
         """Returns a copy of the list of hyperedges in the hypergraph."""
         return list(self._edges)
+
+    def edge_labels(self):
+        """Returns a view of the edge labels used in the hypergraph."""
+        return self._edge_labels.values()
     
     def nonterminals(self):
         """Returns a copy of the list of nonterminals used in the hypergraph."""

--- a/fggs/utils.py
+++ b/fggs/utils.py
@@ -3,7 +3,7 @@ from fggs.fggs import *
 
 
 def unique_label_name(name: str, labs: Iterable[Union[NodeLabel, EdgeLabel]]) -> str:
-    """Given an name, modify it until it does not overlap with
+    """Given a name, modify it until it does not overlap with
     a given set of NodeLabel/EdgeLabel names."""
     names = [lab.name for lab in labs]
     new_name = name
@@ -18,7 +18,7 @@ def singleton_hrg(graph: Graph) -> HRG:
     """Return an HRG which generates just one graph, `graph`."""
 
     # Construct a new edge label name which is not already used in the graph
-    edge_labels = [edge.label for edge in graph.edges()]
+    edge_labels = graph.edge_labels()
     start_name = unique_label_name("<S>", edge_labels)
 
     start   = EdgeLabel(start_name, graph.type, is_nonterminal=True)


### PR DESCRIPTION
- Fix factorize.factorize() to use utils.get_unique_name()
- Expand the set of names that conjunction avoids

Closes #113 