### PR TITLE
Convenience functions for node/edge creation; lighten stringification

### DIFF
--- a/test/test_fggs.py
+++ b/test/test_fggs.py
@@ -250,6 +250,26 @@ class TestGraph(unittest.TestCase):
 
         self.assertEqual(self.graph, copy)
 
+    def test_convenience(self):
+        g = Graph()
+        node1 = g.new_node('nl1', id='node1')
+        node2 = g.new_node('nl2')
+        edge1 = g.new_edge('el1', [node1, node2], is_terminal=True, id='edge1')
+        edge2 = g.new_edge('el2', [node2], is_nonterminal=True)
+        g.ext = [node2]
+
+        self.assertEqual(set(g.nodes()), {node1, node2})
+        self.assertEqual(node1, self.node1)
+        self.assertEqual(node2.label, self.node2.label)
+        self.assertEqual(set(g.edges()), {edge1, edge2})
+        self.assertEqual(edge1.label, self.edge1.label)
+        self.assertEqual(edge1.label, self.edge1.label)
+        self.assertEqual(edge1.nodes, (node1, node2))
+        self.assertEqual(edge2.label, self.edge2.label)
+        self.assertEqual(edge2.nodes, (node2,))
+        self.assertEqual(g.ext, (node2,))
+
+
 class TestHRGRule(unittest.TestCase):
 
     def setUp(self):
@@ -316,6 +336,8 @@ class TestHRG(unittest.TestCase):
         self.hrg.add_edge_label(self.start)
         self.hrg.add_rule(self.rule)
         self.hrg.add_rule(self.rule2)
+
+        print(self.hrg)
 
     def test_add_node_label(self):
         node_labels = self.hrg.node_labels()


### PR DESCRIPTION
Adds the convenience functions suggested in #108. This is just a thin layer on top of existing functions; no changes to the data structures were made (although I think that could be done in the future).

Original interface:
```
        self.nl1   = NodeLabel("nl1")
        self.nl2   = NodeLabel("nl2")
        self.node1 = Node(self.nl1, id='node1')
        self.node2 = Node(self.nl2)

        self.el1   = EdgeLabel("el1", (self.nl1, self.nl2), is_terminal=True)
        self.el2   = EdgeLabel("el2", (self.nl2,), is_nonterminal=True)
        self.edge1 = Edge(self.el1, (self.node1, self.node2), id='edge1')
        self.edge2 = Edge(self.el2, (self.node2,))

        self.graph = Graph()
        self.graph.add_node(self.node1)
        self.graph.add_node(self.node2)
        self.graph.add_edge(self.edge1)
        self.graph.add_edge(self.edge2)
        self.graph.ext = [self.node2]
```

Convenience functions:
```
	g = Graph()
        node1 = g.new_node('nl1', id='node1')
        node2 = g.new_node('nl2')
        edge1 = g.new_edge('el1', [node1, node2], is_terminal=True, id='edge1')
        edge2 = g.new_edge('el2', [node2], is_nonterminal=True)
        g.ext = [node2]
```

Also, I slipped in some changes to make printing of FGGs a little easier to read. Now it looks like this:
```
Graph containing:
  Node node1 with NodeLabel nl1
  Node 4470135968 with NodeLabel nl2
  Edge 4470141904 with Nonterminal EdgeLabel el2 connecting to:
    Node 4470135968 with NodeLabel nl2
  Edge edge1 with Terminal EdgeLabel el1 connecting to:
    Node node1 with NodeLabel nl1
    Node 4470135968 with NodeLabel nl2
```

Closes #108.