### PR TITLE
Labeling mixin

### DIFF
--- a/fggs/fggs.py
+++ b/fggs/fggs.py
@@ -115,7 +115,7 @@ class Edge:
     persist_id: bool        #: Whether the id should be saved with the Node
 
     def __init__(self, label: EdgeLabel, nodes: Iterable[Node], id: Optional[str] = None):
-        # See Node.__post_init__ for further explanation of id and persist_id.
+        # See Node.__init__ for further explanation of id and persist_id.
         if id is None:
             object.__setattr__(self, 'id', _id(self))
             object.__setattr__(self, 'persist_id', False)


### PR DESCRIPTION
I didn't like how much duplicated code (though not duplicated entirely consistently) there was between Graph and HRG for handling node and edge labels. This factors all that code into a single class LabelingMixin.

Alternative: Make both Graph and HRG contain a Labeling object. This is probably more orthodox but adds more complexity to code that uses Graphs and HRGs.
