### PR TITLE
Start symbols

### DIFF
--- a/bin/sum_product.py
+++ b/bin/sum_product.py
@@ -60,7 +60,7 @@ if __name__ == '__main__':
                 fgg.factors[name].weights, p=1, dim=int(dim))
 
     if args.out_weights:
-        out_weights = string_to_tensor(args.out_weights, f"<out_weights>", fgg.shape(fgg.start_symbol))
+        out_weights = string_to_tensor(args.out_weights, f"<out_weights>", fgg.shape(fgg.start))
     else:
         out_weights = 1.
 
@@ -71,7 +71,7 @@ if __name__ == '__main__':
         fac.weights = torch.as_tensor(fac.weights, dtype=torch.get_default_dtype())
 
     zs = fggs.sum_products(fgg, method=args.method)
-    z = zs[fgg.start_symbol]
+    z = zs[fgg.start]
 
     if args.trace:
         for el, zel in zs.items():

--- a/fggs/conjunction.py
+++ b/fggs/conjunction.py
@@ -105,7 +105,7 @@ def conjoin_hrgs(hrg1, hrg2):
         if el1.is_terminal and el2.is_terminal:
             raise ValueError(f"Cannot conjoin hrg1 and hrg2 because they each have a different terminal EdgeLabel called {el1.name}")
     nt_map = nonterminal_pairs(hrg1, hrg2)
-    new_hrg = fggs.HRG(nt_map[hrg1.start_symbol, hrg2.start_symbol])
+    new_hrg = fggs.HRG(nt_map[hrg1.start, hrg2.start])
     # add rules
     for rule1 in hrg1.all_rules():
         for rule2 in hrg2.all_rules():

--- a/fggs/derivations.py
+++ b/fggs/derivations.py
@@ -36,7 +36,7 @@ def start_graph(g: HRG) -> Graph:
     """Construct a graph consisting of a single Edge labeled by the start
     nonterminal symbol."""
     ret = Graph()
-    s = g.start_symbol
+    s = g.start
     e = Edge(s, [Node(l) for l in s.type])
     ret.add_edge(e)
     return ret

--- a/fggs/factorize.py
+++ b/fggs/factorize.py
@@ -421,7 +421,7 @@ def factorize_hrg(g, method='min_fill'):
     """Factorize a HRG's rules into smaller rules, hopefully with
     lower maximum treewidth.
     """
-    gnew = fggs.HRG(g.start_symbol)
+    gnew = fggs.HRG(g.start)
     labels = set(g.edge_labels())
     for r in g.all_rules():
         for rnew in factorize_rule(r, method=method, labels=labels):

--- a/fggs/fggs.py
+++ b/fggs/fggs.py
@@ -372,15 +372,15 @@ class HRG(LabelingMixin, object):
             # Assume that the derived graph has no external nodes
             start = EdgeLabel(start, [], is_nonterminal=True)
         start = cast(EdgeLabel, start)
-        self.start_symbol: EdgeLabel = start
+        self.start: EdgeLabel = start
 
     @property
-    def start_symbol(self) -> EdgeLabel:
+    def start(self) -> EdgeLabel:
         """The start nonterminal symbol."""
         return self._start
 
-    @start_symbol.setter
-    def start_symbol(self, start: EdgeLabel):
+    @start.setter
+    def start(self, start: EdgeLabel):
         if not start.is_nonterminal:
             raise ValueError('Start symbol must be a nonterminal')
         self.add_edge_label(start)
@@ -416,7 +416,7 @@ class HRG(LabelingMixin, object):
     
     def copy(self):
         """Returns a copy of this HRG, whose rules are all copies of the original's."""
-        copy = HRG(self.start_symbol)
+        copy = HRG(self.start)
         copy._node_labels = self._node_labels.copy()
         copy._edge_labels = self._edge_labels.copy()
         copy._rules = {}
@@ -431,7 +431,7 @@ class HRG(LabelingMixin, object):
         equal."""
         return (isinstance(other, HRG) and
                 self._rules == other._rules and
-                self.start_symbol == other.start_symbol and
+                self.start == other.start and
                 self._node_labels == other._node_labels and
                 self._edge_labels == other._edge_labels)
     def __ne__(self, other):
@@ -445,7 +445,7 @@ class HRG(LabelingMixin, object):
         string += "\n  Edge labels:"
         for label_name in self._edge_labels.keys():
             string += f"\n{self._edge_labels[label_name].to_string(2)}"
-        string += f"\n  Start symbol {self.start_symbol.name}"
+        string += f"\n  Start symbol {self.start.name}"
         string += f"\n  Productions:"
         for nonterminal in self._rules:
             for rule in self._rules[nonterminal]:
@@ -560,14 +560,14 @@ class FGG(InterpretationMixin, HRG):
     @staticmethod
     def from_hrg(hrg: HRG):
         """Create an FGG out of an HRG and no domains and factors."""
-        fgg = FGG(hrg.start_symbol)
+        fgg = FGG(hrg.start)
         for r in hrg.all_rules():
             fgg.add_rule(r)
         return fgg
 
     def copy(self):
         """Returns a copy of this FGG."""
-        fgg = FGG(self.start_symbol)
+        fgg = FGG(self.start)
         fgg._node_labels = self._node_labels.copy()
         fgg._edge_labels = self._edge_labels.copy()
         fgg._rules = {}

--- a/fggs/fggs.py
+++ b/fggs/fggs.py
@@ -153,15 +153,15 @@ class LabelingMixin:
         """Adds a node label to the set of used node labels."""
         self._node_labels[label.name] = label
 
-    def has_node_label_name(self, name):
+    def has_node_label_name(self, name: str) -> bool:
         """Returns true if there is a used node label with the given name."""
         return name in self._node_labels.keys()
 
-    def get_node_label(self, name):
+    def get_node_label(self, name: str) -> NodeLabel:
         """Returns the unique used node label with the given name."""
         return self._node_labels[name]
 
-    def node_labels(self):
+    def node_labels(self) -> Iterable[NodeLabel]:
         """Returns a view of the node labels used."""
         return self._node_labels.values()
 
@@ -172,23 +172,23 @@ class LabelingMixin:
             raise Exception(f"There is already an edge label called {name}.")
         self._edge_labels[name] = label
         
-    def has_edge_label_name(self, name):
+    def has_edge_label_name(self, name: str) -> bool:
         """Returns true if there is an edge label with the given name."""
         return name in self._edge_labels.keys()
 
-    def get_edge_label(self, name):
+    def get_edge_label(self, name: str) -> EdgeLabel:
         """Returns the unique used edge label with the given name."""
         return self._edge_labels[name]
 
-    def edge_labels(self):
+    def edge_labels(self) -> Iterable[EdgeLabel]:
         """Returns a view of the edge labels used."""
         return self._edge_labels.values()
     
-    def nonterminals(self):
+    def nonterminals(self) -> Iterable[EdgeLabel]:
         """Returns a copy of the list of nonterminals used."""
         return [el for el in self._edge_labels.values() if el.is_nonterminal]
     
-    def terminals(self):
+    def terminals(self) -> Iterable[EdgeLabel]:
         """Returns a copy of the list of terminals used."""
         return [el for el in self._edge_labels.values() if el.is_terminal]
 
@@ -376,9 +376,9 @@ class HRG(LabelingMixin, object):
         self._edge_labels: Dict[str, EdgeLabel] = dict()
         self._rules: Dict[EdgeLabel, List[HRGRule]] = dict()
         if start is not None:
-            self.start = start
+            self.start = start # type: ignore
         else:
-            self.start = None
+            self.start = None # type: ignore
 
     @property
     def start(self) -> EdgeLabel:
@@ -388,9 +388,9 @@ class HRG(LabelingMixin, object):
     @start.setter
     def start(self, start: Union[EdgeLabel, str]):
         if isinstance(start, str):
-            try:
+            if self.has_edge_label_name(start):
                 start = self.get_edge_label(start)
-            except KeyError:
+            else:
                 start = EdgeLabel(start, [], is_nonterminal=True)
         if start.is_terminal:
             raise ValueError('Start symbol must be a nonterminal')
@@ -561,9 +561,12 @@ class FactorGraph(InterpretationMixin, Graph):
         return fg
         
 class FGG(InterpretationMixin, HRG):
-    """A factor graph grammar."""
+    """A factor graph grammar. If start is a str and there isn't already
+      an EdgeLabel by that name, it's assumed that its arity is
+      zero.
+    """
     
-    def __init__(self, start: Union[EdgeLabel, str]):
+    def __init__(self, start: Union[EdgeLabel, str, None]):
         super().__init__(start)
         self.domains: Dict[str, Domain] = {}
         self.factors: Dict[str, Factor] = {}

--- a/fggs/fggs.py
+++ b/fggs/fggs.py
@@ -169,7 +169,7 @@ class LabelingMixin:
         """Adds an edge label to the set of used edge labels."""
         name = label.name
         if name in self._edge_labels.keys() and self._edge_labels[name] != label:
-            raise Exception(f"There is already an edge label called {name}.")
+            raise ValueError(f"There is already an edge label called {name}.")
         self._edge_labels[name] = label
         
     def has_edge_label_name(self, name: str) -> bool:
@@ -238,6 +238,7 @@ class Graph(LabelingMixin, object):
         """Adds a node to the hypergraph."""
         if node.id in self._nodes.keys():
             raise ValueError(f"Can't have two nodes with same ID {node.id} in same Graph.")
+        self.add_node_label(node.label)
         self._nodes[node.id] = node
 
     def has_node_id(self, nid: str):
@@ -265,11 +266,10 @@ class Graph(LabelingMixin, object):
         """Adds a hyperedge to the hypergraph. If the attachment nodes are not already in the hypergraph, they are added."""
         if edge.id in self._edges.keys():
             raise ValueError(f"Can't have two edges with same ID {edge.id} in same Graph.")
-        if edge.label.name in self._edge_labels.keys() and edge.label != self._edge_labels[edge.label.name]:
-            raise ValueError(f"Can't have two edge labels with same name {edge.label.name} in same Graph.")
         for node in edge.nodes:
             if node.id not in self._nodes.keys():
                 self.add_node(node)
+        self.add_edge_label(edge.label)
         self._edges[edge.id] = edge
         self._edge_labels[edge.label.name] = edge.label
 
@@ -472,8 +472,7 @@ class InterpretationMixin(LabelingMixin):
     
     def add_domain(self, nl: NodeLabel, dom: Domain):
         """Add mapping from NodeLabel nl to Domain dom."""
-        if not self.has_node_label_name(nl.name):
-            self.add_node_label(nl)
+        self.add_node_label(nl)
         if nl.name in self.domains:
             raise ValueError(f"NodeLabel {nl} is already mapped")
         self.domains[nl.name] = dom
@@ -482,8 +481,7 @@ class InterpretationMixin(LabelingMixin):
         """Add mapping from EdgeLabel el to Factor fac."""
         if el.is_nonterminal:
             raise ValueError(f"Nonterminals cannot be mapped to Factors")
-        if not self.has_edge_label_name(el.name):
-            self.add_edge_label(el)
+        self.add_edge_label(el)
         if el in self.factors:
             raise ValueError(f"EdgeLabel {el} is already mapped")
         if fac.arity != el.arity:

--- a/fggs/fggs.py
+++ b/fggs/fggs.py
@@ -362,17 +362,23 @@ class HRGRule:
 
 
 class HRG(LabelingMixin, object):
-    """A hyperedge replacement graph grammar."""
+    """A hyperedge replacement graph grammar.
     
-    def __init__(self, start: Union[EdgeLabel, str]):
+    Arguments:
+
+    - start (EdgeLabel or str): Start nonterminal symbol. If start is
+      a str and there isn't already an EdgeLabel by that name, it's
+      assumed that its arity is zero.
+    """
+    
+    def __init__(self, start: Union[EdgeLabel, str, None]):
         self._node_labels: Dict[str, NodeLabel] = dict()
         self._edge_labels: Dict[str, EdgeLabel] = dict()
         self._rules: Dict[EdgeLabel, List[HRGRule]] = dict()
-        if isinstance(start, str):
-            # Assume that the derived graph has no external nodes
-            start = EdgeLabel(start, [], is_nonterminal=True)
-        start = cast(EdgeLabel, start)
-        self.start: EdgeLabel = start
+        if start is not None:
+            self.start = start
+        else:
+            self.start = None
 
     @property
     def start(self) -> EdgeLabel:
@@ -380,8 +386,13 @@ class HRG(LabelingMixin, object):
         return self._start
 
     @start.setter
-    def start(self, start: EdgeLabel):
-        if not start.is_nonterminal:
+    def start(self, start: Union[EdgeLabel, str]):
+        if isinstance(start, str):
+            try:
+                start = self.get_edge_label(start)
+            except KeyError:
+                start = EdgeLabel(start, [], is_nonterminal=True)
+        if start.is_terminal:
             raise ValueError('Start symbol must be a nonterminal')
         self.add_edge_label(start)
         self._start = start

--- a/fggs/formats.py
+++ b/fggs/formats.py
@@ -112,7 +112,7 @@ def hrg_to_json(g):
             'type': [l.name for l in nt.type],
         }
         
-    j['start'] = g.start_symbol.name
+    j['start'] = g.start.name
     
     j['rules'] = []
     for gr in g.all_rules():

--- a/fggs/sum_product.py
+++ b/fggs/sum_product.py
@@ -369,4 +369,6 @@ def sum_product(fgg: FGG, **opts) -> Tensor:
     - kmax: Number of iterations after which iterative algorithms give up.
     """
     all = sum_products(fgg, **opts)
+    if fgg.start is None:
+        raise ValueError("FGG must have a start symbol")
     return all[fgg.start]

--- a/fggs/sum_product.py
+++ b/fggs/sum_product.py
@@ -369,4 +369,4 @@ def sum_product(fgg: FGG, **opts) -> Tensor:
     - kmax: Number of iterations after which iterative algorithms give up.
     """
     all = sum_products(fgg, **opts)
-    return all[fgg.start_symbol]
+    return all[fgg.start]

--- a/fggs/viterbi.py
+++ b/fggs/viterbi.py
@@ -86,8 +86,8 @@ def F_viterbi(fgg: FGG, x: MultiTensor, inputs: MultiTensor, semiring: Semiring)
     return (Fx, lhs_pointer, rhs_pointer)
 
 def viterbi(fgg: FGG, start_asst: Tuple[int,...], opts: Dict) -> FGGDerivation:
-    if len(start_asst) != fgg.start_symbol.arity:
-        raise ValueError(f"Start assignment ({start_asst}) does not have same type as FGG's start symbol ({fgg.start_symbol.type})")
+    if len(start_asst) != fgg.start.arity:
+        raise ValueError(f"Start assignment ({start_asst}) does not have same type as FGG's start symbol ({fgg.start.type})")
     
     semiring = opts['semiring']
     kmax = opts.get('kmax', 1000)
@@ -149,5 +149,5 @@ def viterbi(fgg: FGG, start_asst: Tuple[int,...], opts: Dict) -> FGGDerivation:
         
         return FGGDerivation(fgg, rule, rhs_asst, child_derivs)
 
-    return reconstruct(fgg.start_symbol, start_asst)
+    return reconstruct(fgg.start, start_asst)
 

--- a/test/test_derivations.py
+++ b/test/test_derivations.py
@@ -103,7 +103,7 @@ class TestStartGraph(unittest.TestCase):
         self.hrg = HRG(self.start)
 
     def test_start_graph(self):
-        s = self.hrg.start_symbol
+        s = self.hrg.start
         g = start_graph(self.hrg)
         self.assertEqual([e.label for e in g.edges()], [s])
         self.assertEqual(len(g.nodes()), len(s.type))

--- a/test/test_fggs.py
+++ b/test/test_fggs.py
@@ -386,8 +386,8 @@ class TestHRG(unittest.TestCase):
         self.hrg.add_edge_label(self.start)
         self.hrg.add_edge_label(self.el1)
 
-    def test_set_start_symbol(self):
-        self.assertEqual(self.hrg.start_symbol, self.start)
+    def test_set_start(self):
+        self.assertEqual(self.hrg.start, self.start)
 
     def test_add_rule(self):
         all_rules = self.hrg.all_rules()
@@ -427,7 +427,7 @@ class TestHRG(unittest.TestCase):
         self.assertEqual(hrg, copy)
 
     def test_convenience(self):
-        copy = HRG(self.hrg.start_symbol.name)
+        copy = HRG(self.hrg.start.name)
         for rule in self.hrg.all_rules():
             copy.new_rule(rule.lhs.name, rule.rhs)
         self.assertEqual(self.hrg, copy)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -43,7 +43,7 @@ class TestSingleton(unittest.TestCase):
         g = singleton_hrg(self.graph)
         self.assertCountEqual(g.node_labels(), [self.nl1])
         self.assertCountEqual(g.edge_labels(), [self.el1, self.start])
-        self.assertEqual(g.start_symbol, self.start)
+        self.assertEqual(g.start, self.start)
         self.assertEqual(len(g.all_rules()), 1)
     
     def test_unique_start_name(self):
@@ -52,7 +52,7 @@ class TestSingleton(unittest.TestCase):
         self.graph.add_edge(s1_edge)
         
         g = singleton_hrg(self.graph)
-        self.assertEqual(g.start_symbol.name, "<S>_1")
+        self.assertEqual(g.start.name, "<S>_1")
 
         
 class TestSCC(unittest.TestCase):


### PR DESCRIPTION
This should be a pretty easy one:

- Change `start_symbol` to `start` (to be more consistent and easier to type).
- Allow an HRG/FGG to have an initially unspecified start symbol (closes #155). In #107 it was mentioned that this breaks the invariant that an HRG/FGG always has one start symbol, but invariants are impossible to enforce and I think convenience probably wins.
- Snuck in some simple fixes.