### PR TITLE
WIP: More flexible rule creation with more error checking

### DIFF
--- a/fggs/fggs.py
+++ b/fggs/fggs.py
@@ -342,11 +342,14 @@ class HRGRule:
     _lhs: Optional[EdgeLabel] #: The left-hand side nonterminal.
     rhs: Graph                #: The right-hand side hypergraph fragment.
 
-    def __init__(self, lhs: Optional[EdgeLabel], rhs: Graph):
-        if lhs is not None:
+    def __init__(self, lhs: Optional[EdgeLabel] = None, rhs: Optional[Graph] = None):
+        if lhs is not None and rhs is not None:
             HRGRule._check_lhs_ext(lhs, rhs.ext)
         self._lhs = lhs
-        self.rhs = rhs
+        if rhs is None:
+            self.rhs = Graph()
+        else:
+            self.rhs = rhs
 
     @property
     def lhs(self) -> EdgeLabel:

--- a/fggs/fggs.py
+++ b/fggs/fggs.py
@@ -339,17 +339,21 @@ class HRGRule:
     - rhs: The right-hand side hypergraph fragment.
     """
 
-    _lhs: EdgeLabel #: The left-hand side nonterminal.
-    rhs: Graph      #: The right-hand side hypergraph fragment.
+    _lhs: Optional[EdgeLabel] #: The left-hand side nonterminal.
+    rhs: Graph                #: The right-hand side hypergraph fragment.
 
-    def __init__(self, lhs: EdgeLabel, rhs: Graph):
-        HRGRule._check_lhs_ext(lhs, rhs.ext)
+    def __init__(self, lhs: Optional[EdgeLabel], rhs: Graph):
+        if lhs is not None:
+            HRGRule._check_lhs_ext(lhs, rhs.ext)
         self._lhs = lhs
         self.rhs = rhs
 
     @property
     def lhs(self) -> EdgeLabel:
-        return self._lhs
+        if self._lhs is None:
+            raise ValueError("HRGRule does not have a left-hand side yet)")
+        else:
+            return self._lhs
 
     @lhs.setter
     def lhs(self, el: EdgeLabel):
@@ -358,7 +362,7 @@ class HRGRule:
 
     def copy(self):
         """Returns a copy of this HRGRule, whose right-hand side is a copy of the original's."""
-        return HRGRule(self.lhs, self.rhs.copy())
+        return HRGRule(self._lhs, self.rhs.copy())
 
     def __str__(self):
         return self.to_string(0)
@@ -377,9 +381,13 @@ class HRGRule:
             raise ValueError(f"HRGRule left-hand side type ({','.join(l.name for l in lhs.type)}) must match external node labels ({','.join(l.name for l in ext_type)}).")
 
     def set_lhs_ext(self, lhs: EdgeLabel, ext: Iterable[Node]):
+        """Set an HRGRule's left-hand side (LHS) and external nodes
+        simultaneously. This is useful in situations where setting the
+        LHS and external nodes one at a time would violate the
+        constraint that they must have the same node labels."""
         ext = tuple(ext)
         HRGRule._check_lhs_ext(lhs, ext)
-        self.lhs = lhs
+        self._lhs = lhs
         self.rhs.ext = ext
 
 class HRG(LabelingMixin, object):

--- a/test/test_fggs.py
+++ b/test/test_fggs.py
@@ -299,6 +299,22 @@ class TestHRGRule(unittest.TestCase):
         self.assertNotEqual(id(rule), id(copy))
         self.assertEqual(rule, copy)
 
+    def test_set_lhs_and_ext(self):
+        rule = self.rule.copy()
+        good_ext = list(rule.rhs.nodes())
+        bad_ext = good_ext[:1]
+        nl1 = NodeLabel("nl1")
+        good_lhs = EdgeLabel("good", (nl1, nl1), is_nonterminal=True)
+        bad_lhs = EdgeLabel("good", (nl1,), is_nonterminal=True)
+        rule.lhs = good_lhs
+        with self.assertRaises(ValueError):
+            rule.lhs = bad_lhs
+        rule.set_lhs_ext(good_lhs, good_ext)
+        with self.assertRaises(ValueError):
+            rule.set_lhs_ext(bad_lhs, good_ext)
+        with self.assertRaises(ValueError):
+            rule.set_lhs_ext(good_lhs, bad_ext)
+
 class TestHRG(unittest.TestCase):
 
     def setUp(self):

--- a/test/test_fggs.py
+++ b/test/test_fggs.py
@@ -307,6 +307,10 @@ class TestHRGRule(unittest.TestCase):
         lhs = r.lhs = EdgeLabel("good", (nl1, nl1), is_nonterminal=True)
         self.assertEqual(r.lhs, lhs)
 
+    def test_optional_rhs(self):
+        r = HRGRule()
+        self.assertEqual(r.rhs, Graph())
+
     def test_set_lhs_and_ext(self):
         rule = self.rule.copy()
         good_ext = tuple(rule.rhs.nodes())

--- a/test/test_fggs.py
+++ b/test/test_fggs.py
@@ -282,7 +282,7 @@ class TestHRGRule(unittest.TestCase):
         nonterminal_mismatch = EdgeLabel("nonterminal1", (nl,), is_nonterminal=True)
         nonterminal_match = EdgeLabel("nonterminal2", (nl, nl), is_nonterminal=True)
         
-        graph = Graph()
+        self.rhs = graph = Graph()
         graph.add_node(node1)
         graph.add_node(node2)
         graph.ext = [node1, node2]
@@ -299,21 +299,35 @@ class TestHRGRule(unittest.TestCase):
         self.assertNotEqual(id(rule), id(copy))
         self.assertEqual(rule, copy)
 
+    def test_optional_lhs(self):
+        nl1 = NodeLabel("nl1")
+        r = HRGRule(None, self.rhs)
+        with self.assertRaises(ValueError):
+            r.lhs
+        lhs = r.lhs = EdgeLabel("good", (nl1, nl1), is_nonterminal=True)
+        self.assertEqual(r.lhs, lhs)
+
     def test_set_lhs_and_ext(self):
         rule = self.rule.copy()
-        good_ext = list(rule.rhs.nodes())
+        good_ext = tuple(rule.rhs.nodes())
         bad_ext = good_ext[:1]
         nl1 = NodeLabel("nl1")
         good_lhs = EdgeLabel("good", (nl1, nl1), is_nonterminal=True)
         bad_lhs = EdgeLabel("good", (nl1,), is_nonterminal=True)
         rule.lhs = good_lhs
+        self.assertEqual(rule.lhs, good_lhs)
         with self.assertRaises(ValueError):
             rule.lhs = bad_lhs
         rule.set_lhs_ext(good_lhs, good_ext)
+        self.assertEqual(rule.lhs, good_lhs)
+        self.assertEqual(rule.rhs.ext, good_ext)
         with self.assertRaises(ValueError):
             rule.set_lhs_ext(bad_lhs, good_ext)
         with self.assertRaises(ValueError):
             rule.set_lhs_ext(good_lhs, bad_ext)
+        rule.set_lhs_ext(bad_lhs, bad_ext)
+        self.assertEqual(rule.lhs, bad_lhs)
+        self.assertEqual(rule.rhs.ext, bad_ext)
 
 class TestHRG(unittest.TestCase):
 


### PR DESCRIPTION
This improves checking the constraint that an HRGRule's lhs and rhs types have to match (closes #79).

It also adds more flexibility in creating an HRGRule. This partially helps with #140.

- Analogous to #156, an HRGRule can be created with no lhs at first, and the the lhs can be set later.
- Every time the lhs is set, it is checked for compatibility with rhs.ext.
- If HRGRule is called with no rhs, an empty rhs is constructed.
- New method HRGRule.set_lhs_ext for setting the lhs and rhs.ext simultaneously.
- If rhs.ext is changed, it is *not* checked for compatibility with lhs.

The alternative to the last point would be if we moved ext from Graph to HRGRule. In other words, Graph would be just a hypergraph (not a "hypergraph fragment") and an HRGRule would have an lhs, a rhs, and external nodes. Then HRGRule would be able to check the consistency of lhs and ext perfectly. However, there would be no way to stop someone from deleting an external node. I prefer this alternative (since I envision node deletion being much less common then setting the external nodes).

(This PR is part of a larger plan to fix #140 and generally try to simplify things.)