### PR TITLE
Allow json.interpretation.domains with unused node label

### DIFF
--- a/fggs/fggs.py
+++ b/fggs/fggs.py
@@ -155,7 +155,7 @@ class LabelingMixin:
 
     def has_node_label_name(self, name: str) -> bool:
         """Returns true if there is a used node label with the given name."""
-        return name in self._node_labels.keys()
+        return name in self._node_labels
 
     def get_node_label(self, name: str) -> NodeLabel:
         """Returns the unique used node label with the given name."""

--- a/fggs/formats.py
+++ b/fggs/formats.py
@@ -17,6 +17,8 @@ def json_to_fgg(j):
 
     ji = j['interpretation']
     for name, d in ji['domains'].items():
+        if not fgg.has_node_label_name(name):
+            fgg.add_node_label(NodeLabel(name))
         nl = fgg.get_node_label(name)
         if d['class'] == 'finite':
             fgg.add_domain(nl, domains.FiniteDomain(d['values']))


### PR DESCRIPTION
This error is triggered by compiling the PERPL program `fail`
so this fix will be tested by https://github.com/diprism/fggs/pull/174
