### PR TITLE
Don't assume in SumProduct that each input has the same sparsity pattern as its gradient (grad_t)

### DIFF
--- a/bin/sum_product.py
+++ b/bin/sum_product.py
@@ -110,7 +110,8 @@ if __name__ == '__main__':
         if args.weights:
             grad_weights = extern_weights
         else:
-            print('no -w or -e is provided, print gradients with respect to factors')
+            print('no -w or -e is provided, print gradients with respect to factors',
+                  file=sys.stderr)
             grad_weights = {}
             for k in fgg.factors.keys():
                 grad_weights[k] = fgg.factors[k].weights.physical

--- a/bin/sum_product.py
+++ b/bin/sum_product.py
@@ -103,7 +103,7 @@ if __name__ == '__main__':
     else:
         print(tensor_to_string(z))
 
-    if args.grad or args.expect:
+    if (args.grad or args.expect) and len(fgg.factors) > 0:
         f = (z * out_weights).sum()
         f.backward()
 

--- a/bin/sum_product.py
+++ b/bin/sum_product.py
@@ -111,10 +111,10 @@ if __name__ == '__main__':
         f = (z * out_weights).sum()
         f.backward()
 
-        if args.weights:
-            grad_weights = extern_weights
-        else:
+        if args.grad_all:
             grad_weights = {k: v.weights.to_dense() for k, v in fgg.factors.items()}
+        else:
+            grad_weights = extern_weights
 
         for name, weights in grad_weights.items():
             grad = weights.grad

--- a/fggs/indices.py
+++ b/fggs/indices.py
@@ -510,7 +510,7 @@ def project_index(size: Sequence[int],
                   stride: Sequence[int],
                   offset: int) -> torch.Tensor:
     """Given a size, a stride, and an offset, return a 1-D tensor of shape size,
-       in which each element is an offset relative to the begging of the
+       in which each element is an offset relative to the beginning of the
        storage.
 
     """

--- a/fggs/indices.py
+++ b/fggs/indices.py
@@ -94,8 +94,7 @@ import torch_semiring_einsum
 from fggs.semirings import Semiring
 
 __all__ = ['Axis', 'PhysicalAxis', 'ProductAxis', 'productAxis', 'unitAxis', 'SumAxis',
-           'Nonphysical', 'PatternedTensor', 'stack', 'einsum', 'log_viterbi_einsum_forward',
-           'reproject']
+           'Nonphysical', 'PatternedTensor', 'stack', 'einsum', 'log_viterbi_einsum_forward']
 
 Rename = Dict["PhysicalAxis", "PhysicalAxis"]
 # populated by Axis.freshen
@@ -481,86 +480,6 @@ class SumAxis(Axis):
                 raise IndexError
         return 0 <= i < n and self.term.index(physical, i)
 
-def project_shape(v_offset: int,
-                  v_stride: Sequence[int],
-                  paxes: Optional[Sequence[PhysicalAxis]],
-                  vaxes: Sequence[Axis],
-                  subst: Subst) -> Tuple[Sequence[int], Sequence[int], int, Sequence[PhysicalAxis]]:
-    offset = v_offset
-    stride : Dict[PhysicalAxis, int] = {}
-    for e, n in zip(vaxes, v_stride):
-        o, s = e.stride(subst)
-        offset += o * n
-        for k in s: stride[k] = stride.get(k, 0) + s[k] * n
-    if paxes is None:
-        paxes = tuple(stride.keys())
-    else:
-        if __debug__:
-            vaxes_fv = frozenset(stride.keys())
-            paxes_fv = frozenset(paxes)
-            if vaxes_fv != paxes_fv:
-                raise ValueError(f"project(..., paxes with {paxes_fv}, vaxes with {vaxes_fv})")
-    new_size = tuple(k._numel  for k in paxes)
-    new_stride = tuple(stride[k] for k in paxes)
-    new_offset = torch.zeros(len(new_stride), dtype=torch.int)
-    return new_size, new_stride, offset, paxes
-
-
-def project_index(size: Sequence[int],
-                  stride: Sequence[int],
-                  offset: int) -> torch.Tensor:
-    """Given a size, a stride, and an offset, return a 1-D tensor of shape size,
-       in which each element is an offset relative to the beginning of the
-       storage.
-
-    """
-    dims = [torch.arange(0, n) for n in size]
-    dim_base = torch.cartesian_prod(*dims) if len(dims) > 0 else torch.tensor(0)
-    dim_stride = torch.tensor(stride) if len(stride) > 0 else torch.tensor(0)
-    dim_indices = dim_base * dim_stride
-    if len(size) > 1:
-        dim_indices = torch.sum(dim_indices, -1, keepdim=False)
-    dim_indices += offset
-    return dim_indices
-
-def reproject(t1: PatternedTensor, t2: PatternedTensor) -> PatternedTensor:
-    """Given two patterned tensors of the same size, convert the first one into
-    the second, with all values not in the second tensor replaced with the
-    default value of the second.
-
-    """
-    if __debug__:
-        if t1.size() != t2.size():
-            raise ValueError(f"reproject(tensor of {t1.size()} is not the same size as tensor of {t2.size()}")
-    if t1.numel() == 0 or t2.numel() == 0:
-        return PatternedTensor(torch.zeros_like(t2.physical), t2.paxes, t2.vaxes, t2.default)
-    elif t1.numel() == 1 and t2.numel() == 1:
-        return PatternedTensor(t1.physical, t2.paxes, t2.vaxes, t2.default)
-    elif (t1.paxes == t1.vaxes) and \
-         (t2.paxes == t2.vaxes):
-        # in case paxes == vaxes is true for both t1 and t2, there is no need to
-        # reproject
-        return PatternedTensor(t1.physical, t2.paxes, t2.vaxes, t2.default)
-    else:
-        t1_virtual_stride = t1.size()[1:] + torch.Size([1])
-        t1_size, t1_stride, t1_offset, _ = \
-            project_shape(0, t1_virtual_stride, t1.paxes, t1.vaxes, {})
-        t1_indices = project_index(t1_size, t1_stride, t1_offset)
-
-        t2_virtual_stride = t2.size()[1:] + torch.Size([1])
-        t2_size, t2_stride, t2_offset, _ = \
-            project_shape(0, t2_virtual_stride, t2.paxes, t2.vaxes, {})
-        t2_indices = project_index(t2_size, t2_stride, t2_offset)
-
-        # because torch doesn't support isin until 1.10, we use this instead
-        if len(t2_indices.size()) > 0:
-            out_indices = torch.tensor([True if idx in t1_indices else False for idx in t2_indices], dtype=torch.bool)
-        else:
-            out_indices = t2_indices
-        out_physical = t2.physical * out_indices.view(t2.physical.size())
-
-        return PatternedTensor(out_physical, t2.paxes, t2.vaxes, t2.default)
-
 def project(virtual: Tensor,
             paxes: Optional[Sequence[PhysicalAxis]],
             vaxes: Sequence[Axis],
@@ -577,9 +496,23 @@ def project(virtual: Tensor,
         # Try to optimize for a common case
         return (virtual, cast(Sequence[PhysicalAxis], vaxes))
     offset = virtual.storage_offset()
-    new_size, new_stride, new_offset, new_paxes = \
-        project_shape(offset, virtual.stride(), paxes, vaxes, subst)
-    return (virtual.as_strided(tuple(new_size), tuple(new_stride), new_offset), new_paxes)
+    stride : Dict[PhysicalAxis, int] = {}
+    for e, n in zip(vaxes, virtual.stride()):
+        o, s = e.stride(subst)
+        offset += o * n
+        for k in s: stride[k] = stride.get(k, 0) + s[k] * n
+    if paxes is None:
+        paxes = tuple(stride.keys())
+    else:
+        if __debug__:
+            vaxes_fv = frozenset(stride.keys())
+            paxes_fv = frozenset(paxes)
+            if vaxes_fv != paxes_fv:
+                raise ValueError(f"project(..., paxes with {paxes_fv}, vaxes with {vaxes_fv})")
+    return (virtual.as_strided(tuple(k._numel  for k in paxes),
+                               tuple(stride[k] for k in paxes),
+                               offset),
+            paxes)
 
 def reshape_or_view(f: Callable[[Tensor, List[int]], Tensor],
                     self: PatternedTensor,

--- a/fggs/indices.py
+++ b/fggs/indices.py
@@ -376,8 +376,8 @@ class ProductAxis(Axis):
     factors: Tuple[Axis, ...]
 
     def depict(self, letterer: Callable[[PhysicalAxis], str]) -> str:
-        # Produce a string like "X(2) * Y(3)"
-        return '*'.join(e.depict(letterer) for e in self.factors)
+        # Produce a string like "(X(2) * Y(3))"
+        return f'({"*".join(e.depict(letterer) for e in self.factors)})'
 
     def numel(self) -> int:
         return reduce(mul, (e.numel() for e in self.factors), 1)

--- a/fggs/sum_product.py
+++ b/fggs/sum_product.py
@@ -402,7 +402,8 @@ class SumProduct(torch.autograd.Function):
         # Compute gradients of inputs
         grad_t = multi_mv(jf_inputs, grad_nt, transpose=True)
         # TODO: optimize project(to_dense()) composition below
-        grad_in = tuple(project(grad_t[el].to_dense(), np.paxes, np.vaxes, {})[0] for el, np in ctx.in_labels)
+        grad_in = tuple(np.reincarnate(torch.ones_like(physical)).mul(grad_t[el]).physical
+                        for (el, np), physical in zip(ctx.in_labels, ctx.saved_tensors))
 
         return (None, None, None, None) + grad_in
 

--- a/fggs/sum_product.py
+++ b/fggs/sum_product.py
@@ -18,7 +18,7 @@ import warnings
 import torch
 from torch import Tensor
 from fggs.typing import TensorLikeT
-from fggs.indices import Nonphysical, PatternedTensor, einsum, stack, reproject
+from fggs.indices import Nonphysical, PatternedTensor, einsum, stack
 
 Function = Callable[[MultiTensor], MultiTensor]
 
@@ -401,7 +401,7 @@ class SumProduct(torch.autograd.Function):
                     
         # Compute gradients of inputs
         grad_t = multi_mv(jf_inputs, grad_nt, transpose=True)
-        grad_in = tuple(reproject(grad_t[el], inputs[el]).physical for el, _ in ctx.in_labels)
+        grad_in = tuple(grad_t[el].project(np.paxes, np.vaxes) for el, np in ctx.in_labels)
 
         return (None, None, None, None) + grad_in
 

--- a/fggs/sum_product.py
+++ b/fggs/sum_product.py
@@ -18,7 +18,7 @@ import warnings
 import torch
 from torch import Tensor
 from fggs.typing import TensorLikeT
-from fggs.indices import Nonphysical, PatternedTensor, einsum, stack, project
+from fggs.indices import Nonphysical, PatternedTensor, einsum, stack, reproject
 
 Function = Callable[[MultiTensor], MultiTensor]
 
@@ -401,9 +401,7 @@ class SumProduct(torch.autograd.Function):
                     
         # Compute gradients of inputs
         grad_t = multi_mv(jf_inputs, grad_nt, transpose=True)
-        # TODO: optimize project(to_dense()) composition below
-        grad_in = tuple(np.reincarnate(torch.ones_like(physical)).mul(grad_t[el]).physical
-                        for (el, np), physical in zip(ctx.in_labels, ctx.saved_tensors))
+        grad_in = tuple(reproject(grad_t[el], inputs[el]).physical for el, _ in ctx.in_labels)
 
         return (None, None, None, None) + grad_in
 

--- a/fggs/sum_product.py
+++ b/fggs/sum_product.py
@@ -18,7 +18,7 @@ import warnings
 import torch
 from torch import Tensor
 from fggs.typing import TensorLikeT
-from fggs.indices import PatternedTensor, einsum, stack
+from fggs.indices import Nonphysical, PatternedTensor, einsum, stack, project
 
 Function = Callable[[MultiTensor], MultiTensor]
 
@@ -319,16 +319,17 @@ class SumProduct(torch.autograd.Function):
       - el[i] is the EdgeLabel and
       - in_np[i] is the nonphysical part of the PatternedTensor
         that is the sum-product of el[i].
-        A nonphysical part of a PatternedTensor pt is a function
-        that produces pt when passed the Tensor pt.physical.
+        A nonphysical part of a PatternedTensor pt is a Nonphysical object
+        whose reincarnate() method produces pt when passed the Tensor
+        pt.physical.
     - out_labels: The nonterminal EdgeLabels whose sum-products to compute.
     - in_values: A sequence of Tensors such that the PatternedTensor
-      in_np[i](in_values[i]) is the sum-product of in_labels[i].
+      in_np[i].reincarnate(in_values[i]) is the sum-product of in_labels[i].
 
     Returns: A sequence (out_np, *out_values), where
     - out_np consists of len(out_labels) nonphysical parts and
     - out_values consists of len(out_labels) Tensors,
-    such that out_np[i](out_values[i]) is the sum-product of
+    such that out_np[i].reincarnate(out_values[i]) is the sum-product of
     out_labels[i].
     """
     
@@ -336,11 +337,11 @@ class SumProduct(torch.autograd.Function):
     def forward(ctx, # type: ignore
                 fgg: FGG,
                 opts: Dict,
-                in_labels: Sequence[Tuple[EdgeLabel, Callable[[Tensor], PatternedTensor]]],
+                in_labels: Sequence[Tuple[EdgeLabel, Nonphysical]],
                 out_labels: Sequence[EdgeLabel],
                 *in_values: Tensor) -> Tuple[Union[
-            Tuple[Optional[Callable[[Tensor], PatternedTensor]], ...], # first tuple component (same length as out_labels)
-            Optional[Tensor]                                           # rest tuple components (same length as out_labels)
+            Tuple[Optional[Nonphysical], ...], # first tuple component (same length as out_labels)
+            Optional[Tensor]                   # rest tuple components (same length as out_labels)
         ], ...]:
         ctx.fgg = fgg
         method, semiring = opts['method'], opts['semiring']
@@ -349,7 +350,7 @@ class SumProduct(torch.autograd.Function):
         ctx.out_labels = out_labels
         ctx.save_for_backward(*in_values)
 
-        inputs: MultiTensor = {label: nonphysical(physical) for (label, nonphysical), physical in zip(in_labels, in_values)} # type: ignore
+        inputs: MultiTensor = {label: nonphysical.reincarnate(physical) for (label, nonphysical), physical in zip(in_labels, in_values)} # type: ignore
 
         if method == 'linear':
             out = linear(fgg, inputs, out_labels, semiring)
@@ -377,15 +378,12 @@ class SumProduct(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_nonphysicals, *grad_out):
         semiring = ctx.opts['semiring']
-        def from_dense(t: Tensor) -> PatternedTensor:
-            return PatternedTensor(t, default=semiring.from_int(0).item())
         # gradients are always computed in the real semiring
         real_semiring = RealSemiring(dtype=semiring.dtype, device=semiring.device)
-        # TODO: should from_dense sometimes use default=real_semiring.from_int(0).item()?
 
         # Construct and solve linear system of equations
-        inputs = {label: nonphysical(physical) for (label, nonphysical), physical in zip(ctx.in_labels, ctx.saved_tensors)}
-        f = {nt: ctx.out_values[nt].nonphysical()(g)
+        inputs = {label: nonphysical.reincarnate(physical) for (label, nonphysical), physical in zip(ctx.in_labels, ctx.saved_tensors)}
+        f = {nt: ctx.out_values[nt].nonphysical().default_to_nan().reincarnate(g)
              for nt, g in zip(ctx.out_labels, grad_out)
              if g is not None}
 
@@ -403,8 +401,9 @@ class SumProduct(torch.autograd.Function):
                     
         # Compute gradients of inputs
         grad_t = multi_mv(jf_inputs, grad_nt, transpose=True)
-        grad_in = tuple(grad_t[el].to_dense() for el, _ in ctx.in_labels)
-        
+        # TODO: optimize project(to_dense()) composition below
+        grad_in = tuple(project(grad_t[el].to_dense(), np.paxes, np.vaxes, {})[0] for el, np in ctx.in_labels)
+
         return (None, None, None, None) + grad_in
 
     @staticmethod
@@ -417,7 +416,7 @@ class SumProduct(torch.autograd.Function):
             *(tensor.physical for tensor in in_values))
         return tuple(PatternedTensor(opts['semiring'].zeros(fgg.shape(nt)))
                      if nonphysical is None is physical
-                     else nonphysical(physical)
+                     else nonphysical.reincarnate(physical)
                      for nt, nonphysical, physical in zip(out_labels, nonphysicals, physicals))
 
 def sum_products(fgg: FGG, **opts) -> Dict[EdgeLabel, Tensor]:

--- a/test/test_indices.py
+++ b/test/test_indices.py
@@ -235,6 +235,11 @@ class TestPatternedTensor(unittest.TestCase):
                 self.assertTrue(t1_.equal(t2_) and t2_.equal(t1_))
                 self.assertTEqual(t1_.to_dense(), t2_.to_dense())
 
+    def test_project(self):
+        self.assertTEqual(PatternedTensor(torch.Tensor([1,2,3]), (self.k3,), (SumAxis(0,ProductAxis(()),1), self.k3), 9)
+                          .project((self.k2,), (self.k2, SumAxis(0,self.k2,1))),
+                          torch.Tensor([1,9]))
+
     def test_equal_default(self):
         self.assertFalse(PatternedTensor(torch.Tensor([-1,0,1]), (self.k3,), (self.k3, self.k3)).equal_default())
         self.assertTrue (PatternedTensor(torch.Tensor([ 0,0,0]), (self.k3,), (self.k3, self.k3)).equal_default())

--- a/test/test_sum_product.py
+++ b/test/test_sum_product.py
@@ -104,7 +104,7 @@ class TestSumProduct(unittest.TestCase):
                         fgg, opts, in_labels, out_labels, *physicals)
                     return tuple(torch.zeros(fgg.shape(nt))
                                  if nonphysical is None is physical
-                                 else nonphysical(physical).to_dense()
+                                 else nonphysical.reincarnate(physical).to_dense()
                                  for nt, nonphysical, physical in zip(out_labels, nonphysicals, physicals))
 
                 self.assertTrue(torch.autograd.gradcheck(f, tuple(tensor.physical for tensor in in_values), atol=1e-3))
@@ -127,7 +127,7 @@ class TestSumProduct(unittest.TestCase):
                     # put exp inside f to avoid gradcheck computing -inf - -inf
                     return tuple(torch.zeros(fgg.shape(nt))
                                  if nonphysical is None is physical
-                                 else nonphysical(physical).exp().to_dense()
+                                 else nonphysical.reincarnate(physical).exp().to_dense()
                                  for nt, nonphysical, physical in zip(out_labels, nonphysicals, physicals))
                 self.assertTrue(torch.autograd.gradcheck(f, tuple(tensor.physical for tensor in in_values), atol=1e-3))
 

--- a/test/test_sum_product.sh
+++ b/test/test_sum_product.sh
@@ -24,7 +24,7 @@ for case in "${all_test_cases[@]}"; do
     file=${file_and_ans[0]}
     ans=${file_and_ans[1]}
     printf '%-40s' "Testing ${file}... "
-    result=$(./perplc $file | ${PYTHON:-python} bin/sum_product.py -d /dev/stdin)
+    result=$(./perplc $file | ${PYTHON:-python} bin/sum_product.py -g -d /dev/stdin)
     if [ $? = 0 ]; then
         correct=$(echo ${ans} | round)
         out=$(echo ${result} | round)

--- a/test/test_sum_product.sh
+++ b/test/test_sum_product.sh
@@ -24,7 +24,7 @@ for case in "${all_test_cases[@]}"; do
     file=${file_and_ans[0]}
     ans=${file_and_ans[1]}
     printf '%-40s' "Testing ${file}... "
-    result=$(./perplc $file | ${PYTHON:-python} bin/sum_product.py -g -d /dev/stdin)
+    result=$(./perplc $file | ${PYTHON:-python} bin/sum_product.py -G -d /dev/stdin)
     if [ $? = 0 ]; then
         correct=$(echo ${ans} | round)
         out=$(echo ${result} | sed -E 's|([^grad]*)grad.*|\1|g' | round)

--- a/test/test_sum_product.sh
+++ b/test/test_sum_product.sh
@@ -27,10 +27,12 @@ for case in "${all_test_cases[@]}"; do
     result=$(./perplc $file | ${PYTHON:-python} bin/sum_product.py -g -d /dev/stdin)
     if [ $? = 0 ]; then
         correct=$(echo ${ans} | round)
-        out=$(echo ${result} | round)
+        out=$(echo ${result} | sed -E 's|([^grad]*)grad.*|\1|g' | round)
+        nl=$'\n'
+        grad=$(echo ${result} | sed -E 's|([^grad]*)(grad.*)|\2|g' | sed -E 's/grad/'"\\${nl}"'/g')
         if [ -n "$correct" ]; then
             if [ "$correct" = "$out" ]; then
-                echo "Success"
+                echo "Success, gradients: ${grad}"
             else
                 echo "Failure"
                 echo "Incorrect result in ${file}: ${correct} != ${out}"


### PR DESCRIPTION
Fixes: #173 

To facilitate testing, add command-line option -G to differentiate wrt all factors

Defunctionalize what PatternedTensor.nonphysical() used to return

Add PatternedTensor.project() using Axis.unify()

Change default returned by PatternedTensor.grad() to NaN (because those gradients are not zero but uncomputed)

Work around torch_semiring_einsum's not handling 0 elements