### PR TITLE
Return weights in a dictionary that contains the symbolic names.

### DIFF
--- a/bin/sum_product.py
+++ b/bin/sum_product.py
@@ -20,14 +20,11 @@ def string_to_tensor(s, name="tensor", shape=None):
         error(f"{name} should have shape {shape}")
     return t
 
-def tensor_to_string(t):
-    return json.dumps(fggs.formats.weights_to_json(t))
-
 def tensor_to_dict_string(is_pretty, fgg, node, t):
     if is_pretty:
         return json.dumps(fggs.formats.weights_to_dict_json(fgg, node, t))
     else:
-        return tensor_to_string(t)
+        return json.dumps(fggs.formats.weights_to_json(t))
 
 if __name__ == '__main__':
     ap = argparse.ArgumentParser(description='Compute the sum-product of an FGG.')
@@ -124,11 +121,12 @@ if __name__ == '__main__':
             grad_weights = extern_weights
 
         for name, weights in grad_weights.items():
+            edge = fgg.get_edge_label(name)
             grad = weights.grad
             
             if args.grad or args.grad_all:
-                print(f'grad[{name}]:', tensor_to_string(grad))
+                print(f'grad[{name}]:', tensor_to_dict_string(args.pretty, fgg, edge, grad))
 
             if args.expect:
                 expect = grad * weights / f
-                print(f'E[#{name}]:', tensor_to_string(expect))
+                print(f'E[#{name}]:', tensor_to_dict_string(args.pretty, fgg, edge, expect))

--- a/bin/sum_product.py
+++ b/bin/sum_product.py
@@ -23,8 +23,11 @@ def string_to_tensor(s, name="tensor", shape=None):
 def tensor_to_string(t):
     return json.dumps(fggs.formats.weights_to_json(t))
 
-def tensor_to_dict_string(fgg, node, t):
-    return json.dumps(fggs.formats.weights_to_dict_json(fgg, node, t))
+def tensor_to_dict_string(is_pretty, fgg, node, t):
+    if is_pretty:
+        return json.dumps(fggs.formats.weights_to_dict_json(fgg, node, t))
+    else:
+        return tensor_to_string(t)
 
 if __name__ == '__main__':
     ap = argparse.ArgumentParser(description='Compute the sum-product of an FGG.')
@@ -40,6 +43,7 @@ if __name__ == '__main__':
     ap.add_argument('-e', dest='expect', action='store_true', help='compute expected counts of factor(s) from -w option(s)')
     ap.add_argument('-t', dest='trace', action='store_true', help='print out all intermediate sum-products')
     ap.add_argument('-d', dest='double', action='store_true', help='use double-precision floating-point')
+    ap.add_argument('-p', dest='pretty', action='store_true', help='pretty print weights together with the value names')
 
     args = ap.parse_args()
     if args.double: torch.set_default_dtype(torch.float64)
@@ -106,9 +110,9 @@ if __name__ == '__main__':
 
     if args.trace:
         for el, zel in zs.items():
-            print(tensor_to_dict_string(fgg, el, zel))
+            print(tensor_to_dict_string(args.pretty, fgg, el, zel))
     else:
-        print(tensor_to_dict_string(fgg, fgg.start, z))
+        print(tensor_to_dict_string(args.pretty, fgg, fgg.start, z))
 
     if (args.grad_all or args.grad or args.expect) and len(fgg.factors) > 0:
         f = (z * out_weights).sum()

--- a/bin/sum_product.py
+++ b/bin/sum_product.py
@@ -23,6 +23,9 @@ def string_to_tensor(s, name="tensor", shape=None):
 def tensor_to_string(t):
     return json.dumps(fggs.formats.weights_to_json(t))
 
+def tensor_to_dict_string(fgg, node, t):
+    return json.dumps(fggs.formats.weights_to_dict_json(fgg, node, t))
+
 if __name__ == '__main__':
     ap = argparse.ArgumentParser(description='Compute the sum-product of an FGG.')
     ap.add_argument('fgg', metavar='<fgg>', help='the FGG, in JSON format')
@@ -103,9 +106,9 @@ if __name__ == '__main__':
 
     if args.trace:
         for el, zel in zs.items():
-            print(el.name, tensor_to_string(zel))
+            print(tensor_to_dict_string(fgg, el, zel))
     else:
-        print(tensor_to_string(z))
+        print(tensor_to_dict_string(fgg, fgg.start, z))
 
     if (args.grad_all or args.grad or args.expect) and len(fgg.factors) > 0:
         f = (z * out_weights).sum()

--- a/fggs/formats.py
+++ b/fggs/formats.py
@@ -9,6 +9,7 @@ from fggs.indices import PhysicalAxis, productAxis, SumAxis, PatternedTensor
 from fggs import domains, factors
 import torch
 from torch import Tensor
+from typing import cast
 
 ### JSON
 
@@ -189,8 +190,10 @@ def weights_to_dict_json(fgg : FGG, edge_label : EdgeLabel, weights : Tensor):
 
     domains_dict = fgg.domains
     edge_type = edge_label.type
-    if all(n.name in domains_dict for n in edge_type):
-        edge_type_sizes = [domains_dict[n.name].size() for n in edge_type]
+    if all(n.name in domains_dict and
+           isinstance(domains_dict[n.name], domains.FiniteDomain)
+           for n in edge_type):
+        edge_type_sizes = [cast(domains.FiniteDomain, domains_dict[n.name]).size() for n in edge_type]
         if torch.Size(edge_type_sizes) == weights.shape:
             return to_dict(edge_type, edge_type_sizes, (), weights)
         else:

--- a/fggs/formats.py
+++ b/fggs/formats.py
@@ -8,6 +8,7 @@ from fggs.fggs import *
 from fggs.indices import PhysicalAxis, productAxis, SumAxis, PatternedTensor
 from fggs import domains, factors
 import torch
+from torch import Tensor
 
 ### JSON
 
@@ -174,6 +175,29 @@ def weights_to_json(weights):
         return float(weights)
     else:
         return [weights_to_json(w) for w in weights]
+
+
+def weights_to_dict_json(fgg : FGG, edge_label : EdgeLabel, weights : Tensor):
+    def to_dict(edge_type, edge_type_sizes, indices, weights):
+        if len(edge_type_sizes) == 0:
+            return weights[indices].item()
+        else:
+            return {fgg.domains[edge_type[0].name].denumberize(i):
+                    to_dict(edge_type[1:], edge_type_sizes[1:],
+                            indices + (i,), weights)
+                    for i in range(edge_type_sizes[0])}
+
+    domains_dict = fgg.domains
+    edge_type = edge_label.type
+    if all(n.name in domains_dict for n in edge_type):
+        edge_type_sizes = [domains_dict[n.name].size() for n in edge_type]
+        if torch.Size(edge_type_sizes) == weights.shape:
+            return to_dict(edge_type, edge_type_sizes, (), weights)
+        else:
+            return weights_to_json(weights)
+    else:
+        return weights_to_json(weights)
+
 
 def json_to_axis(r, env):
     if isinstance(r, list):


### PR DESCRIPTION
This solves issues #181 and [#141](https://github.com/diprism/perpl/issues/141). This is not enabled by default so that current test cases won't be influenced. If `-p` is passed, the output will be a dictionary like `{"False":0, "True":0}`. Otherwise the weight is still a list like `[0, 0]`.