### PR TITLE
Support compact domain to save loading time.

### DIFF
--- a/fggs/domains.py
+++ b/fggs/domains.py
@@ -1,4 +1,4 @@
-__all__ = ['Domain', 'FiniteDomain']
+__all__ = ['Domain', 'FiniteDomain', 'CompactDomain']
 
 from abc import ABC, abstractmethod
 
@@ -52,6 +52,36 @@ class FiniteDomain(Domain):
         else:
             return type(self) == type(other) and \
                    self.values == other.values
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+class CompactDomain(Domain):
+    """A compact domain for finite sets (like vocabularies).
+
+    Compact domain is like finite domain, but it doesn't hold
+    vocabularies. Instead it only holds the size of values.
+
+    """
+
+    def __init__(self, size):
+        super().__init__()
+        self._size = size
+
+    def size(self):
+        "Return the size of the domain."
+        return self._size
+
+    def contains(self, value):
+        pass
+
+    def __eq__(self, other):
+        if self is other:
+            return True
+        else:
+            return type(self) == type(other) and \
+                   self.size() == other.size()
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/fggs/domains.py
+++ b/fggs/domains.py
@@ -99,7 +99,7 @@ class RangeDomain(Domain):
 
     def denumberize(self, num):
         """Convert a numberized value back to the original value."""
-        return str(num)
+        return num
 
     def __eq__(self, other):
         if self is other:

--- a/fggs/domains.py
+++ b/fggs/domains.py
@@ -6,7 +6,11 @@ from abc import ABC, abstractmethod
 # TODO: need some way to either sum over or integrate over?
 class Domain(ABC):
     """Abstract base class for domains."""
-    
+
+    @abstractmethod
+    def to_json(self):
+        pass
+
     @abstractmethod
     def contains(self, value):
         pass
@@ -29,6 +33,9 @@ class FiniteDomain(Domain):
         super().__init__()
         self.values = list(values)
         self._value_index = {v:i for (i,v) in enumerate(values)}
+
+    def to_json(self):
+        return {'class': 'finite', 'values': list(self.values)}
 
     def contains(self, value):
         return value in self.values
@@ -72,6 +79,9 @@ class RangeDomain(Domain):
     def size(self):
         "Return the size of the domain."
         return self._size
+
+    def to_json(self):
+        return {'class': 'range', 'size': self._size}
 
     def contains(self, value):
         return 0 <= value < self._size

--- a/fggs/domains.py
+++ b/fggs/domains.py
@@ -1,4 +1,4 @@
-__all__ = ['Domain', 'FiniteDomain', 'CompactDomain']
+__all__ = ['Domain', 'FiniteDomain', 'RangeDomain']
 
 from abc import ABC, abstractmethod
 
@@ -57,10 +57,10 @@ class FiniteDomain(Domain):
         return not self.__eq__(other)
 
 
-class CompactDomain(Domain):
-    """A compact domain for finite sets (like vocabularies).
+class RangeDomain(Domain):
+    """A range domain for finite sets.
 
-    Compact domain is like finite domain, but it doesn't hold
+    Range domain is like finite domain, but it doesn't hold
     vocabularies. Instead it only holds the size of values.
 
     """
@@ -74,7 +74,18 @@ class CompactDomain(Domain):
         return self._size
 
     def contains(self, value):
-        pass
+        return 0 <= value < self._size
+
+    def numberize(self, num):
+        """Convert a value into an integer.
+        Since a range domain only has a size, this is actually an identify
+        function.
+        """
+        return num
+
+    def denumberize(self, num):
+        """Convert a numberized value back to the original value."""
+        return str(num)
 
     def __eq__(self, other):
         if self is other:

--- a/fggs/domains.py
+++ b/fggs/domains.py
@@ -70,11 +70,10 @@ class FiniteDomain(Domain):
 
 
 class RangeDomain(Domain):
-    """A range domain for finite sets.
+    """A domain for natural numbers up to a given size.
 
     Range domain is like finite domain, but it doesn't hold
     vocabularies. Instead it only holds the size of values.
-
     """
 
     def __init__(self, size):
@@ -93,7 +92,7 @@ class RangeDomain(Domain):
 
     def numberize(self, num):
         """Convert a value into an integer.
-        Since a range domain only has a size, this is actually an identify
+        Since a range domain only has a size, this is actually an identity
         function.
         """
         return num

--- a/fggs/domains.py
+++ b/fggs/domains.py
@@ -1,6 +1,7 @@
 __all__ = ['Domain', 'FiniteDomain', 'RangeDomain']
 
 from abc import ABC, abstractmethod
+from math import inf
 
 # this somehow needs to be able to express continuous and discrete infinite domains
 # TODO: need some way to either sum over or integrate over?
@@ -14,6 +15,10 @@ class Domain(ABC):
     @abstractmethod
     def contains(self, value):
         pass
+
+    @abstractmethod
+    def size(self):
+        return inf
 
     def __eq__(self, other):
         return self is other
@@ -76,15 +81,15 @@ class RangeDomain(Domain):
         super().__init__()
         self._size = size
 
-    def size(self):
-        "Return the size of the domain."
-        return self._size
-
     def to_json(self):
         return {'class': 'range', 'size': self._size}
 
     def contains(self, value):
         return 0 <= value < self._size
+
+    def size(self):
+        """Return the size of the domain."""
+        return self._size
 
     def numberize(self, num):
         """Convert a value into an integer.

--- a/fggs/factors.py
+++ b/fggs/factors.py
@@ -55,8 +55,10 @@ class FiniteFactor(Factor):
           - or a torch.Tensor,
           - or a fggs.indices.PatternedTensor"""
         
-        if not all(isinstance(d, domains.FiniteDomain) for d in doms):
-            raise TypeError('FiniteFactor can only be applied to FiniteDomains')
+        if not all(isinstance(d, domains.FiniteDomain) or
+                   isinstance(d, domains.CompactDomain)
+                   for d in doms):
+            raise TypeError('FiniteFactor can only be applied to FiniteDomains/CompactDomains')
         super().__init__(doms)
 
         self.weights = weights

--- a/fggs/factors.py
+++ b/fggs/factors.py
@@ -1,6 +1,7 @@
 __all__ = ['Factor', 'ConstantFactor', 'FiniteFactor']
 
 from abc import ABC, abstractmethod
+from math import isfinite
 from fggs import domains
 from fggs.indices import PatternedTensor
 import torch
@@ -49,15 +50,14 @@ class FiniteFactor(Factor):
         """A factor that can define an arbitrary function on finite domains.
 
         - doms: domains of arguments
-          - a list of FiniteDomain
+          - a list of domains whose size()s are finite
         - weights: weights
           - a list (of lists)* of floats,
           - or a torch.Tensor,
           - or a fggs.indices.PatternedTensor"""
         
-        if not all(isinstance(d, (domains.FiniteDomain, domains.RangeDomain))
-                   for d in doms):
-            raise TypeError('FiniteFactor can only be applied to FiniteDomains/RangeDomains')
+        if not all(isfinite(d.size()) for d in doms):
+            raise TypeError('FiniteFactor can only be applied to finite domains')
         super().__init__(doms)
 
         self.weights = weights

--- a/fggs/factors.py
+++ b/fggs/factors.py
@@ -55,10 +55,9 @@ class FiniteFactor(Factor):
           - or a torch.Tensor,
           - or a fggs.indices.PatternedTensor"""
         
-        if not all(isinstance(d, domains.FiniteDomain) or
-                   isinstance(d, domains.CompactDomain)
+        if not all(isinstance(d, (domains.FiniteDomain, domains.RangeDomain))
                    for d in doms):
-            raise TypeError('FiniteFactor can only be applied to FiniteDomains/CompactDomains')
+            raise TypeError('FiniteFactor can only be applied to FiniteDomains/RangeDomains')
         super().__init__(doms)
 
         self.weights = weights

--- a/fggs/fggs.py
+++ b/fggs/fggs.py
@@ -510,7 +510,7 @@ class InterpretationMixin(LabelingMixin):
             nls = x.type
         else:
             nls = x.label.type
-        return tuple(cast(FiniteDomain, self.domains[nl.name]).size() for nl in nls)
+        return tuple(self.domains[nl.name].size() for nl in nls)
     
     def new_finite_domain(self, name: str, values: Sequence):
         """Convenience function for creating and adding a FiniteDomain at the same time."""

--- a/fggs/formats.py
+++ b/fggs/formats.py
@@ -4,6 +4,7 @@ __all__ = ['json_to_fgg', 'fgg_to_json',
            'graph_to_dot', 'graph_to_tikz', 'hrg_to_tikz']
 
 from itertools import repeat
+from math import isfinite
 from fggs.fggs import *
 from fggs.indices import PhysicalAxis, productAxis, SumAxis, PatternedTensor
 from fggs import domains, factors
@@ -186,7 +187,7 @@ def weights_to_dict_json(fgg : FGG, edge_label : EdgeLabel, weights : Tensor):
     domains_dict = fgg.domains
     edge_type = edge_label.type
     if all(n.name in domains_dict and
-           isinstance(domains_dict[n.name], domains.FiniteDomain)
+           isfinite(domains_dict[n.name].size())
            for n in edge_type):
         edge_type_sizes = [cast(domains.FiniteDomain, domains_dict[n.name]).size() for n in edge_type]
         if torch.Size(edge_type_sizes) == weights.shape:

--- a/fggs/formats.py
+++ b/fggs/formats.py
@@ -25,7 +25,7 @@ def json_to_fgg(j):
         nl = fgg.get_node_label(name)
         if d['class'] == 'finite':
             fgg.add_domain(nl, domains.FiniteDomain(d['values']))
-        elif d['class'] == 'compact':
+        elif d['class'] == 'range':
             fgg.add_domain(nl, domains.RangeDomain(d['size']))
         else:
             raise ValueError(f'invalid domain class: {d["type"]}')
@@ -46,15 +46,7 @@ def fgg_to_json(fgg):
     
     ji = {}
 
-    ji['domains'] = {}
-    for nl, dom in fgg.domains.items():
-        if isinstance(dom, domains.FiniteDomain):
-            ji['domains'][nl] = {
-                'class' : 'finite',
-                'values' : list(dom.values),
-            }
-        else:
-            raise NotImplementedError(f'unsupported domain type {type(j.domain)}')
+    ji['domains'] = {nl: dom.to_json() for nl, dom in fgg.domains.items()}
 
     ji['factors'] = {}
     for el, fac in fgg.factors.items():

--- a/fggs/formats.py
+++ b/fggs/formats.py
@@ -25,6 +25,8 @@ def json_to_fgg(j):
         nl = fgg.get_node_label(name)
         if d['class'] == 'finite':
             fgg.add_domain(nl, domains.FiniteDomain(d['values']))
+        elif d['class'] == 'compact':
+            fgg.add_domain(nl, domains.CompactDomain(d['values']))
         else:
             raise ValueError(f'invalid domain class: {d["type"]}')
 

--- a/fggs/formats.py
+++ b/fggs/formats.py
@@ -26,7 +26,7 @@ def json_to_fgg(j):
         if d['class'] == 'finite':
             fgg.add_domain(nl, domains.FiniteDomain(d['values']))
         elif d['class'] == 'compact':
-            fgg.add_domain(nl, domains.CompactDomain(d['values']))
+            fgg.add_domain(nl, domains.RangeDomain(d['size']))
         else:
             raise ValueError(f'invalid domain class: {d["type"]}')
 

--- a/fggs/sum_product.py
+++ b/fggs/sum_product.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 __all__ = ['sum_product', 'sum_products']
 
 from fggs.fggs import FGG, HRG, HRGRule, EdgeLabel, Edge, Node
-from fggs.domains import FiniteDomain
 from fggs.factors import FiniteFactor
 from fggs.semirings import *
 from fggs.multi import *
@@ -226,7 +225,7 @@ def sum_product_edges(fgg: FGG, nodes: Iterable[Node], edges: Iterable[Edge], ex
             ext.append(ncopy)
             connected.update([n, ncopy])
             indexing.append([n, ncopy])
-            nsize = cast(FiniteDomain, fgg.domains[n.label.name]).size()
+            nsize = fgg.domains[n.label.name].size()
             tensors.append(PatternedTensor.eye(nsize,semiring))
             #duplicate = True # Uncomment this line for debugging messages
         else:
@@ -261,7 +260,7 @@ def sum_product_edges(fgg: FGG, nodes: Iterable[Node], edges: Iterable[Edge], ex
     multiplier = 1
     for n in nodes:
         if n not in connected and n not in ext:
-            multiplier *= cast(FiniteDomain, fgg.domains[n.label.name]).size()
+            multiplier *= fgg.domains[n.label.name].size()
     if multiplier != 1:
         out = semiring.mul(out, PatternedTensor.from_int(multiplier, semiring))
     assert(out.physical.dtype == semiring.dtype)


### PR DESCRIPTION
Support a new domain format "compact". In the compact mode, the filed "values" in the FGG JSON is an `int` that represents the size of the domain. This size will be used later so that there is no need to record every value. This will save a lot of time and space when the FGG domains contain a large number of values.