### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 torch>=1.9
+numpy<2
 pydot
-git+https://github.com/bdusell/semiring-einsum
+torch-semiring-einsum>=1.2
 tqdm
 mypy
 packaging


### PR DESCRIPTION
Updated to use the latest semiring-einsum.

Also added a requirement for numpy<2, since version 2 had some breaking changes.

Partially fixes #185.