### PR TITLE
Optimize memory usage and efficiency of einsum.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: require haskell
-      uses: haskell/actions/setup@v2
+      uses: haskell-actions/setup@v2
       with:
         ghc-version: '9.2.4'
     - name: checkout perpl
@@ -18,7 +18,7 @@ jobs:
       run: make
       working-directory: ./perpl
     - name: prepare artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: perpl
         path: |
@@ -38,7 +38,7 @@ jobs:
       - name: install python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -48,7 +48,7 @@ jobs:
       - name: check types
         run: make typecheck
       - name: download perpl
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: perpl
       - name: perform unit testing
@@ -60,7 +60,7 @@ jobs:
     needs: prepare
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
     steps:
       - run: echo "checking out branch ${{ github.ref }} on ${{ github.repository }}."
       - name: checkout repository
@@ -76,7 +76,7 @@ jobs:
       - name: check types
         run: make typecheck
       - name: download perpl
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: perpl
       - name: perform unit testing

--- a/bin/sum_product.py
+++ b/bin/sum_product.py
@@ -120,7 +120,7 @@ if __name__ == '__main__':
         print(tensor_to_dict_string(args.pretty, fgg, fgg.start, z))
 
     if (args.grad_all or args.grad or args.expect) and len(fgg.factors) > 0:
-        f = (z * out_weights).sum()
+        f = (z.to_dense() * out_weights).sum()
         f.backward()
 
         if args.grad_all:

--- a/fggs/sum_product.py
+++ b/fggs/sum_product.py
@@ -465,16 +465,17 @@ class SumProduct(torch.autograd.Function):
             if method == 'fixed-point':
                 fixed_point(lambda x: F(fgg, x, inputs, semiring),
                             x0, tol=opts['tol'], kmax=opts['kmax'])
+                out = x0
             elif method == 'newton':
                 newton(lambda x: F(fgg, x, inputs, semiring),
                        lambda x: J_precompute_products(fgg, x, inputs, semiring)
                        if j_precompute else J(fgg, x, inputs, semiring),
                        x0, tol=opts['tol'], kmax=opts['kmax'])
+                out = x0
             elif method == 'one-step':
-                x0.copy_(F(fgg, x0, inputs, semiring))
+                out = F(fgg, x0, inputs, semiring)
             else:
                 raise ValueError('unsupported method for computing sum-product')
-            out = x0
 
         ctx.out_values = out
         return tuple(chain((tuple(out[nt].nonphysical() if nt in out else None
@@ -563,7 +564,7 @@ def sum_products(fgg: FGG, **opts) -> Dict[EdgeLabel, Tensor]:
         comp_labels = list(comp)
         comp_values = SumProduct.apply_to_patterned_tensors(fgg, comp_opts, inputs.keys(), comp_labels, *inputs.values())
         all.update(zip(comp_labels, comp_values))
-    return {label: t.to_dense() for label, t in all.items()}
+    return all
         
 def sum_product(fgg: FGG, **opts) -> Tensor:
     """Compute the sum-product of an FGG.

--- a/fggs/sum_product.py
+++ b/fggs/sum_product.py
@@ -529,7 +529,7 @@ class SumProduct(torch.autograd.Function):
                      else nonphysical.reincarnate(physical)
                      for nt, nonphysical, physical in zip(out_labels, nonphysicals, physicals))
 
-def sum_products(fgg: FGG, **opts) -> Dict[EdgeLabel, Tensor]:
+def sum_products(fgg: FGG, **opts) -> Dict[EdgeLabel, PatternedTensor]:
     opts.setdefault('method',   'fixed-point')
     opts.setdefault('semiring', RealSemiring())
     opts.setdefault('tol',      1e-5) # with float32, 1e-6 can fail
@@ -566,7 +566,7 @@ def sum_products(fgg: FGG, **opts) -> Dict[EdgeLabel, Tensor]:
         all.update(zip(comp_labels, comp_values))
     return all
         
-def sum_product(fgg: FGG, **opts) -> Tensor:
+def sum_product(fgg: FGG, **opts) -> PatternedTensor:
     """Compute the sum-product of an FGG.
     
     - fgg: The FGG to compute the sum-product of.


### PR DESCRIPTION
* Optimize memory use of `einsum` by reducing equations of `einsum` when inputs' `physical` are expanded tensor. In this case we can first compute `einsum` by using the tensors before expanding with a reduced equation and then invoke `torch.expand`.
* Change the return type of `fggs.sum_product` from `Tensor` to `PatternedTensor` so that we don't need to allocate memory for the result instantly if `PatternedTensor.to_dense()` needs a lot of space.
* Update test cases corresponding to the changes above.
* Update CI workflow to make it compatible with the latest action changes.