### PR TITLE
Change sum_product to return PatternedTensor instead of Tensor

### DIFF
--- a/bin/sum_product.py
+++ b/bin/sum_product.py
@@ -120,7 +120,7 @@ if __name__ == '__main__':
         print(tensor_to_dict_string(args.pretty, fgg, fgg.start, z))
 
     if (args.grad_all or args.grad or args.expect) and len(fgg.factors) > 0:
-        f = (z * out_weights).sum()
+        f = (z.to_dense() * out_weights).sum()
         f.backward()
 
         if args.grad_all:

--- a/fggs/sum_product.py
+++ b/fggs/sum_product.py
@@ -465,16 +465,17 @@ class SumProduct(torch.autograd.Function):
             if method == 'fixed-point':
                 fixed_point(lambda x: F(fgg, x, inputs, semiring),
                             x0, tol=opts['tol'], kmax=opts['kmax'])
+                out = x0
             elif method == 'newton':
                 newton(lambda x: F(fgg, x, inputs, semiring),
                        lambda x: J_precompute_products(fgg, x, inputs, semiring)
                        if j_precompute else J(fgg, x, inputs, semiring),
                        x0, tol=opts['tol'], kmax=opts['kmax'])
+                out = x0
             elif method == 'one-step':
-                x0.copy_(F(fgg, x0, inputs, semiring))
+                out = F(fgg, x0, inputs, semiring)
             else:
                 raise ValueError('unsupported method for computing sum-product')
-            out = x0
 
         ctx.out_values = out
         return tuple(chain((tuple(out[nt].nonphysical() if nt in out else None
@@ -528,7 +529,7 @@ class SumProduct(torch.autograd.Function):
                      else nonphysical.reincarnate(physical)
                      for nt, nonphysical, physical in zip(out_labels, nonphysicals, physicals))
 
-def sum_products(fgg: FGG, **opts) -> Dict[EdgeLabel, Tensor]:
+def sum_products(fgg: FGG, **opts) -> Dict[EdgeLabel, PatternedTensor]:
     opts.setdefault('method',   'fixed-point')
     opts.setdefault('semiring', RealSemiring())
     opts.setdefault('tol',      1e-5) # with float32, 1e-6 can fail
@@ -563,9 +564,9 @@ def sum_products(fgg: FGG, **opts) -> Dict[EdgeLabel, Tensor]:
         comp_labels = list(comp)
         comp_values = SumProduct.apply_to_patterned_tensors(fgg, comp_opts, inputs.keys(), comp_labels, *inputs.values())
         all.update(zip(comp_labels, comp_values))
-    return {label: t.to_dense() for label, t in all.items()}
+    return all
         
-def sum_product(fgg: FGG, **opts) -> Tensor:
+def sum_product(fgg: FGG, **opts) -> PatternedTensor:
     """Compute the sum-product of an FGG.
     
     - fgg: The FGG to compute the sum-product of.


### PR DESCRIPTION
This way we don't need to allocate memory for the result instantly if PatternedTensor.to_dense() needs a lot of space.

This commit cherry-picks the changes to */*sum_product.py in https://github.com/diprism/fggs/pull/192

This is work by @chihyang